### PR TITLE
Make overlay frame customizable, and improve detection stability

### DIFF
--- a/IPDFCameraViewController/IPDFCameraViewController.h
+++ b/IPDFCameraViewController/IPDFCameraViewController.h
@@ -14,6 +14,8 @@ typedef NS_ENUM(NSInteger,IPDFCameraViewType)
     IPDFCameraViewTypeNormal
 };
 
+typedef void(^RenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
+
 @interface IPDFCameraViewController : UIView
 
 - (void)setupCameraView;
@@ -24,10 +26,16 @@ typedef NS_ENUM(NSInteger,IPDFCameraViewType)
 @property (nonatomic,assign,getter=isBorderDetectionEnabled) BOOL enableBorderDetection;
 @property (nonatomic,assign,getter=isTorchEnabled) BOOL enableTorch;
 
+@property (nonatomic, assign) float refreshInterval;
+@property (nonatomic, assign) BOOL postEdit;
+@property (nonatomic, assign) RenderBlock overlayRenderBlock;
+
 @property (nonatomic,assign) IPDFCameraViewType cameraViewType;
 
+- (void)setEnableBorderDetection:(BOOL)enable;
 - (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)())completionHandler;
-
 - (void)captureImageWithCompletionHander:(void(^)(NSString *imageFilePath))completionHandler;
+- (void)captureImageForPostEditWithCompletionHander:(void(^)(NSString *imgPath, NSArray *features))handler;
+- (void)setBorderDetectionFrameStyle:(UIColor *)fill border:(UIColor *)borderColor borderWidth:(float) width;
 
 @end

--- a/IPDFCameraViewController/IPDFCameraViewController.h
+++ b/IPDFCameraViewController/IPDFCameraViewController.h
@@ -14,8 +14,6 @@ typedef NS_ENUM(NSInteger,IPDFCameraViewType)
     IPDFCameraViewTypeNormal
 };
 
-typedef void(^RenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
-
 @interface IPDFCameraViewController : UIView
 
 - (void)setupCameraView;
@@ -28,10 +26,11 @@ typedef void(^RenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoi
 
 @property (nonatomic, assign) float refreshInterval;
 @property (nonatomic, assign) BOOL postEdit;
-@property (nonatomic, assign) RenderBlock overlayRenderBlock;
+@property (nonatomic, assign) void(^overlayRenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
 
 @property (nonatomic,assign) IPDFCameraViewType cameraViewType;
 
+- (void)overrideOverlayRenderMethod:(void(^)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight)) block;
 - (void)setEnableBorderDetection:(BOOL)enable;
 - (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)())completionHandler;
 - (void)captureImageWithCompletionHander:(void(^)(NSString *imageFilePath))completionHandler;

--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -156,7 +156,7 @@
     
 }
 
--(void)setOverlayRenderBlock:(RenderBlock) block
+-(void)overrideOverlayRenderMethod:(void(^)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight)) block
 {
     [overlayFrameView setOverlayRenderHandler:block];
 }

--- a/IPDFCameraViewController/IPDFCameraViewOverlay.h
+++ b/IPDFCameraViewController/IPDFCameraViewOverlay.h
@@ -13,11 +13,9 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-typedef void(^RenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
-
 @interface OverlayFrame : UIView
 
-@property (nonatomic, assign) RenderBlock overlayRenderHandler;
+@property (nonatomic, assign) void(^overlayRenderHandler)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
 
 -(void) updateFrame:(CIRectangleFeature *)rectFeature rawRect:(CGSize)rawRect;
 -(void) clearOverlayFrame;

--- a/IPDFCameraViewController/IPDFCameraViewOverlay.h
+++ b/IPDFCameraViewController/IPDFCameraViewOverlay.h
@@ -1,0 +1,29 @@
+//
+//  IPDFCameraViewOverlay.h
+//  InstaPDF
+//
+//  Created by Maximilian Mackh on 06/01/15.
+//  Copyright (c) 2015 mackh ag. All rights reserved.
+//
+
+
+#ifndef IPDFCameraViewOverlay_h
+#define IPDFCameraViewOverlay_h
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+typedef void(^RenderBlock)(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight);
+
+@interface OverlayFrame : UIView
+
+@property (nonatomic, assign) RenderBlock overlayRenderHandler;
+
+-(void) updateFrame:(CIRectangleFeature *)rectFeature rawRect:(CGSize)rawRect;
+-(void) clearOverlayFrame;
+-(NSArray *) getLastFeatures;
+-(void) setFrameStyle:(UIColor *)fill borderColor:(UIColor *)stroke borderWidth:(float)width;
+
+@end
+
+#endif /* IPDFCameraViewOverlay_h */

--- a/IPDFCameraViewController/IPDFCameraViewOverlay.m
+++ b/IPDFCameraViewController/IPDFCameraViewOverlay.m
@@ -1,0 +1,290 @@
+//
+//  IPDFCameraViewOverlay.m
+//  InstaPDF
+//
+//  Created by Maximilian Mackh on 06/01/15.
+//  Copyright (c) 2015 mackh ag. All rights reserved.
+//
+
+
+#import "IPDFCameraViewOverlay.h"
+
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <QuartzCore/QuartzCore.h>
+#import <CoreImage/CoreImage.h>
+#import <ImageIO/ImageIO.h>
+
+#define SHOW_DEBUGGER_OVERLAY 0
+
+#define textAtPoint(text, point) [text drawAtPoint:CGPointMake(point.x - text.length*3, point.y) withAttributes:[NSDictionary dictionaryWithObjects: \
+@[[UIFont fontWithName:@"Helvetica Neue" size:10.0], [UIColor whiteColor]] forKeys:@[NSFontAttributeName, NSForegroundColorAttributeName]]];
+
+#define roundPointStr(point, offsetY) NSStringFromCGPoint(CGPointMake(roundf(point.x), roundf(point.y + offsetY)))
+
+@implementation OverlayFrame {
+    CIRectangleFeature * borderRectFeature;
+    CGSize rawImageRect;
+    NSMutableArray * lastDetectedFeatures;
+    CGAffineTransform viewMatrix;
+    BOOL drawOverlay;
+    NSMutableArray * queue;
+    NSMutableArray * rejectedQueue;
+    UIColor * frameBorderColor;
+    UIColor * frameFillColor;
+    float frameBorderWidth;
+}
+
+@synthesize overlayRenderHandler;
+
+-(id) init
+{
+    self = [super init];
+    queue = [[NSMutableArray alloc] init];
+    rejectedQueue = [[NSMutableArray alloc]init];
+    frameBorderColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0];
+    frameFillColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:0.4];
+    frameBorderWidth = 3;
+    lastDetectedFeatures = [[NSMutableArray alloc]init];
+    return self;
+}
+
+-(NSArray *) getLastFeatures
+{
+    return lastDetectedFeatures;
+}
+
+-(void) setFrameStyle:(UIColor *)fill borderColor:(UIColor *)stroke borderWidth:(float)width
+{
+    frameBorderWidth = width;
+    frameFillColor = fill;
+    frameBorderColor = stroke;
+    
+}
+
+-(BOOL) pointFilter:(NSArray *) features
+{
+    CGPoint fTopLeft = [[features objectAtIndex:0] CGPointValue];
+    CGPoint fTopRight = [[features objectAtIndex:1] CGPointValue];
+    CGPoint fBottomLeft = [[features objectAtIndex:2] CGPointValue];
+    CGPoint fBottomRight = [[features objectAtIndex:3] CGPointValue];
+    
+    CGFloat avgX = 0;
+    CGFloat avgY = 0;
+    
+    // compute average
+    for(NSArray * p in queue)
+    {
+        CGPoint topLeft = [[p objectAtIndex:0] CGPointValue];
+        CGPoint topRight = [[p objectAtIndex:1] CGPointValue];
+        CGPoint bottomLeft = [[p objectAtIndex:2] CGPointValue];
+        CGPoint bottomRight = [[p objectAtIndex:3] CGPointValue];
+        avgX += topLeft.x + topRight.x + bottomLeft.x + bottomRight.x;
+        avgY += topRight.y + topRight.y + bottomRight.y + bottomLeft.y;
+    }
+    avgX /= queue.count*4;
+    avgY /= queue.count*4;
+    CGPoint fScore = [self getFeatureScore:fTopLeft topRight:fTopRight bottomLeft:fBottomLeft bottomRight:fBottomRight];
+    
+    float scoreX = fScore.x / avgX;
+    float scoreY = fScore.y / avgY;
+    
+#if SHOW_DEBUGGER_OVERLAY == 1
+    textAtPoint(NSStringFromCGPoint(CGPointMake(roundf(scoreX*100), roundf(scoreY*100))), CGPointMake(self.frame.size.width/2, self.frame.size.height/2 + 24));
+#endif
+    
+    // tolerance 10%
+    if(fabs(1 - scoreX) > 0.1 || fabs(1 - scoreY) > 0.1) {
+        // when consecutive 9 frames corrected, restart the score base
+        if(rejectedQueue.count < 9)
+        {
+            [rejectedQueue addObject:@[ [NSValue valueWithCGPoint:fTopLeft], [NSValue valueWithCGPoint:fTopRight], [NSValue valueWithCGPoint:fBottomLeft], [NSValue valueWithCGPoint:fBottomRight]]];
+        }
+        else
+        {
+            [queue removeAllObjects];
+            [rejectedQueue removeAllObjects];
+            
+        }
+        return NO;
+    }
+    else {
+        [rejectedQueue removeAllObjects];
+        if(queue.count < 6)
+        {
+            [queue addObject:@[ [NSValue valueWithCGPoint:fTopLeft], [NSValue valueWithCGPoint:fTopRight], [NSValue valueWithCGPoint:fBottomLeft], [NSValue valueWithCGPoint:fBottomRight]]];
+        }
+        else
+        {
+            [queue removeObjectAtIndex:0];
+            [queue addObject:@[ [NSValue valueWithCGPoint:fTopLeft], [NSValue valueWithCGPoint:fTopRight], [NSValue valueWithCGPoint:fBottomLeft], [NSValue valueWithCGPoint:fBottomRight]]];
+        }
+        return YES;
+    }
+}
+
+-(CGPoint) getFeatureScore:(CGPoint)topLeft topRight:(CGPoint)topRight bottomLeft:(CGPoint)bottomLeft bottomRight:(CGPoint)bottomRight
+{
+    CGFloat avgX = (topLeft.x + topRight.x + bottomLeft.x + bottomRight.x)/4;
+    CGFloat avgY = (topRight.y + topRight.y + bottomRight.y + bottomLeft.y)/4;
+    return CGPointMake(avgX, avgY);
+}
+
+-(void) updateFrame:(CIRectangleFeature *)rectFeature rawRect:(CGSize)rawRect
+{
+    borderRectFeature = rectFeature;
+    rawImageRect = rawRect;
+    drawOverlay = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self setNeedsDisplay];
+    });
+}
+
+-(void) drawRect:(CGRect)rect
+{
+    if(borderRectFeature == nil) {
+        return;
+    }
+    
+    
+    if(drawOverlay == NO)
+    {
+        #if SHOW_DEBUGGER_OVERLAY == 1
+        [self drawDebugLayer:UIGraphicsGetCurrentContext() rect:rect text:@"NO REGION DETECTED"];
+        #endif
+    }
+    else
+    {
+        #if SHOW_DEBUGGER_OVERLAY == 1
+        [self drawDebugLayer:UIGraphicsGetCurrentContext() rect:rect text:@"TEST MODE"];
+        #endif
+        [self drawOVerlay:UIGraphicsGetCurrentContext() rect:rect ];
+    }
+    
+}
+
+-(void) drawDebugLayer:(CGContextRef)ctx rect:(CGRect)rect text:(NSString *)text
+{
+
+#if SHOW_DEBUGGER_OVERLAY == 1
+    textAtPoint(text, CGPointMake(rect.size.width/2, rect.size.height/2));
+    CGContextSetFillColorWithColor(ctx, frameFillColor.CGColor);
+    CGContextSetRGBFillColor(ctx, 0.0, 1.0, 0.0, 1.0);
+    CGContextSetLineWidth(ctx, 2.0);
+    CGContextSetRGBFillColor(ctx, 0, 0, 1, 0.25);
+    CGContextFillRect(ctx, CGRectMake(0, 0, rect.size.width/2, rect.size.height/2));
+    CGContextSetRGBFillColor(ctx, 0, 1, 0, 0.25);
+    CGContextFillRect(ctx, CGRectMake(rect.size.width/2, rect.size.height/2, rect.size.width/2, rect.size.height/2));
+#endif
+}
+
+-(void) clearOverlayFrame
+{
+    drawOverlay = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self setNeedsDisplay];
+    });
+}
+
+-(void) drawOVerlay:(CGContextRef)ctx rect:(CGRect)rect
+{
+    CGPoint topLeft = borderRectFeature.topLeft;
+    CGPoint topRight = borderRectFeature.topRight;
+    CGPoint bottomLeft = borderRectFeature.bottomLeft;
+    CGPoint bottomRight = borderRectFeature.bottomRight;
+    
+    topLeft = CGContextConvertPointToUserSpace(ctx, topLeft);
+    topRight = CGContextConvertPointToUserSpace(ctx, topRight);
+    bottomLeft = CGContextConvertPointToUserSpace(ctx, bottomLeft);
+    bottomRight = CGContextConvertPointToUserSpace(ctx, bottomRight);
+
+    if(overlayRenderHandler != nil)
+    {
+        overlayRenderHandler(ctx, rect, topLeft, topRight, bottomLeft, bottomRight);
+        return;
+    }
+    
+    viewMatrix = CGAffineTransformMake(2*rect.size.width/rawImageRect.width, 0, 0, -2*rect.size.height/rawImageRect.height, 0, rect.size.height);
+    
+    topLeft = CGPointApplyAffineTransform(topLeft, viewMatrix);
+    topRight = CGPointApplyAffineTransform(topRight, viewMatrix);
+    bottomLeft = CGPointApplyAffineTransform(bottomLeft, viewMatrix);
+    bottomRight = CGPointApplyAffineTransform(bottomRight, viewMatrix);
+    
+    BOOL draw = [self pointFilter:@[ [NSValue valueWithCGPoint:topLeft], [NSValue valueWithCGPoint:topRight], [NSValue valueWithCGPoint:bottomLeft], [NSValue valueWithCGPoint:bottomRight] ]];
+
+#if SHOW_DEBUGGER_OVERLAY == 1
+    // frame before corrected (blue)
+    CGContextSetLineWidth(ctx, 1);
+    CGContextSetRGBStrokeColor(ctx, 0, 0, 1, 1);
+    CGContextBeginPath(ctx);
+    CGContextMoveToPoint(ctx, topLeft.x, topLeft.y);
+    CGContextAddLineToPoint(ctx, topRight.x, topRight.y);
+    CGContextAddLineToPoint(ctx, bottomRight.x, bottomRight.y);
+    CGContextAddLineToPoint(ctx, bottomLeft.x, bottomLeft.y);
+    CGContextClosePath(ctx);
+    CGContextStrokePath(ctx);
+#endif
+    
+    // the feature points are regarded as noise, use last valid feature point set
+    if(!draw)
+    {
+        if(queue.count < 6)
+            return;
+        NSArray * previousFrame = [queue objectAtIndex:3];
+        topLeft = [[previousFrame objectAtIndex:0] CGPointValue];
+        topRight = [[previousFrame objectAtIndex:1] CGPointValue];
+        bottomLeft = [[previousFrame objectAtIndex:2] CGPointValue];
+        bottomRight = [[previousFrame objectAtIndex:3] CGPointValue];
+        [UIView animateWithDuration:0.3f animations:^{
+            [self setAlpha:1.0f];
+        } completion:nil];
+        
+    }
+    
+    // overlay region
+    CGContextBeginPath(ctx);
+    CGContextSetFillColorWithColor(ctx, frameFillColor.CGColor);
+    CGContextSetStrokeColorWithColor(ctx, frameBorderColor.CGColor);
+
+#if SHOW_DEBUGGER_OVERLAY == 1
+    
+    if(draw == NO)
+    {
+        textAtPoint(@"CORRECTED", CGPointMake(rect.size.width/2 - 24, rect.size.height/2 - 24));
+        CGContextSetRGBStrokeColor(ctx, 0, 1, 0, 1);
+        CGContextSetFillColorWithColor(ctx, frameFillColor.CGColor);
+    }
+#endif
+
+    
+    CGContextSetLineWidth(ctx, frameBorderWidth);
+    CGContextSetLineJoin(ctx, kCGLineJoinRound);
+    
+    CGContextBeginPath(ctx);
+    CGContextMoveToPoint(ctx, topLeft.x, topLeft.y);
+    CGContextAddLineToPoint(ctx, topRight.x, topRight.y);
+    CGContextAddLineToPoint(ctx, bottomRight.x, bottomRight.y);
+    CGContextAddLineToPoint(ctx, bottomLeft.x, bottomLeft.y);
+    CGContextClosePath(ctx);
+    CGContextDrawPath(ctx, kCGPathFillStroke);
+    lastDetectedFeatures = [[NSMutableArray alloc]
+                            initWithObjects:
+                            [NSValue valueWithCGPoint:topLeft ],
+                            [NSValue valueWithCGPoint:topRight ],
+                            [NSValue valueWithCGPoint:bottomLeft ],
+                            [NSValue valueWithCGPoint:bottomRight ],
+                            nil];
+    
+#if SHOW_DEBUGGER_OVERLAY == 1
+    // show coord of feature points
+    textAtPoint(roundPointStr(topLeft, 0), topLeft);
+    textAtPoint(roundPointStr(topRight, 12), topRight);
+    textAtPoint(roundPointStr(bottomLeft, 0), bottomRight);
+    textAtPoint(roundPointStr(bottomRight, 12), bottomLeft);
+#endif
+    
+    
+}
+
+@end

--- a/IPDFCameraViewController/IPDFCameraViewOverlay.m
+++ b/IPDFCameraViewController/IPDFCameraViewOverlay.m
@@ -197,12 +197,6 @@
     topRight = CGContextConvertPointToUserSpace(ctx, topRight);
     bottomLeft = CGContextConvertPointToUserSpace(ctx, bottomLeft);
     bottomRight = CGContextConvertPointToUserSpace(ctx, bottomRight);
-
-    if(overlayRenderHandler != nil)
-    {
-        overlayRenderHandler(ctx, rect, topLeft, topRight, bottomLeft, bottomRight);
-        return;
-    }
     
     viewMatrix = CGAffineTransformMake(2*rect.size.width/rawImageRect.width, 0, 0, -2*rect.size.height/rawImageRect.height, 0, rect.size.height);
     
@@ -210,6 +204,12 @@
     topRight = CGPointApplyAffineTransform(topRight, viewMatrix);
     bottomLeft = CGPointApplyAffineTransform(bottomLeft, viewMatrix);
     bottomRight = CGPointApplyAffineTransform(bottomRight, viewMatrix);
+    
+    if(overlayRenderHandler != nil)
+    {
+        overlayRenderHandler(ctx, rect, topLeft, topRight, bottomLeft, bottomRight);
+        return;
+    }
     
     BOOL draw = [self pointFilter:@[ [NSValue valueWithCGPoint:topLeft], [NSValue valueWithCGPoint:topRight], [NSValue valueWithCGPoint:bottomLeft], [NSValue valueWithCGPoint:bottomRight] ]];
 

--- a/IPDFCameraViewController/ViewController.m
+++ b/IPDFCameraViewController/ViewController.m
@@ -32,6 +32,26 @@
     
     [self.cameraViewController setupCameraView];
     [self.cameraViewController setEnableBorderDetection:YES];
+    
+    // set border detection frame style
+    [self.cameraViewController setBorderDetectionFrameStyle:[UIColor colorWithRed:1 green:1 blue:1 alpha:0.3]
+                                                     border:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]
+                                                borderWidth:3];
+    // set border detection interval
+    [self.cameraViewController setRefreshInterval:0.2];
+    
+    // override detection frame render method
+//    [self.cameraViewController overrideOverlayRenderMethod:^(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight) {
+//        CGContextBeginPath(ctx);
+//        CGContextMoveToPoint(ctx, topLeft.x, topLeft.y);
+//        CGContextAddLineToPoint(ctx, topRight.x, topRight.y);
+//        CGContextAddLineToPoint(ctx, bottomRight.x, bottomRight.y);
+//        CGContextAddLineToPoint(ctx, bottomLeft.x, bottomLeft.y);
+//        CGContextSetRGBStrokeColor(ctx, 1, 0, 0, 1);
+//        CGContextClosePath(ctx);
+//        CGContextDrawPath(ctx, kCGPathFillStroke);
+//    }];
+    
     [self updateTitleLabel];
 }
 

--- a/IPDFCameraViewControllerDemo.xcodeproj/project.pbxproj
+++ b/IPDFCameraViewControllerDemo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		22F8A01A1A6279030099DC69 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A0191A6279030099DC69 /* Images.xcassets */; };
 		22F8A01D1A6279030099DC69 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A01B1A6279030099DC69 /* LaunchScreen.xib */; };
 		22F8A0351A62799E0099DC69 /* IPDFCameraViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 22F8A0341A62799E0099DC69 /* IPDFCameraViewController.m */; };
+		A1EDBEAD1D2D071300EA7C73 /* IPDFCameraViewOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = A1EDBEAC1D2D071300EA7C73 /* IPDFCameraViewOverlay.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +30,8 @@
 		22F8A01C1A6279030099DC69 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		22F8A0331A62799E0099DC69 /* IPDFCameraViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPDFCameraViewController.h; sourceTree = "<group>"; };
 		22F8A0341A62799E0099DC69 /* IPDFCameraViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IPDFCameraViewController.m; sourceTree = "<group>"; };
+		A1EDBEAB1D2D071300EA7C73 /* IPDFCameraViewOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPDFCameraViewOverlay.h; sourceTree = "<group>"; };
+		A1EDBEAC1D2D071300EA7C73 /* IPDFCameraViewOverlay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IPDFCameraViewOverlay.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +90,8 @@
 		22F8A0321A6279850099DC69 /* IPDFCameraViewController */ = {
 			isa = PBXGroup;
 			children = (
+				A1EDBEAB1D2D071300EA7C73 /* IPDFCameraViewOverlay.h */,
+				A1EDBEAC1D2D071300EA7C73 /* IPDFCameraViewOverlay.m */,
 				22F8A0331A62799E0099DC69 /* IPDFCameraViewController.h */,
 				22F8A0341A62799E0099DC69 /* IPDFCameraViewController.m */,
 			);
@@ -167,6 +172,7 @@
 				22F8A0151A6279030099DC69 /* ViewController.m in Sources */,
 				22F8A0121A6279030099DC69 /* AppDelegate.m in Sources */,
 				22F8A00F1A6279030099DC69 /* main.m in Sources */,
+				A1EDBEAD1D2D071300EA7C73 /* IPDFCameraViewOverlay.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,6 +313,7 @@
 				22F8A02E1A6279040099DC69 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Hi, I've added some features to this great project, please see if it is appropriate to merge into master.

1.Make border detection overlay customizable (fill coler, border color, and border width)

```objc
    // set border detection frame style
    [self.cameraViewController 
        setBorderDetectionFrameStyle:[UIColor colorWithRed:1 green:1 blue:1 alpha:0.3]
        border:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]
        borderWidth:3];
```

2.Developers can also customize border detection overlay by setting `overlayRenderBlock` property, for example :

```objc

    // override detection frame render method
    [self.cameraViewController overrideOverlayRenderMethod:^(CGContextRef ctx, CGRect rect, CGPoint topLeft, CGPoint topRight, CGPoint bottomLeft, CGPoint bottomRight) {
        CGContextBeginPath(ctx);
        CGContextMoveToPoint(ctx, topLeft.x, topLeft.y);
        CGContextAddLineToPoint(ctx, topRight.x, topRight.y);
        CGContextAddLineToPoint(ctx, bottomRight.x, bottomRight.y);
        CGContextAddLineToPoint(ctx, bottomLeft.x, bottomLeft.y);
        CGContextSetRGBStrokeColor(ctx, 1, 0, 0, 1);
        CGContextClosePath(ctx);
        CGContextDrawPath(ctx, kCGPathFillStroke);
    }];
    
```

Set `overlayRenderBlock` to `nil` will use default overlay.

3.Add a property `refreshInterval` so that developers can change border detection timer interval.

```objc
    // set border detection interval
    [self.cameraViewController setRefreshInterval:0.2];
```

4.When I've added a [filter function](https://github.com/wkh237/IPDFCameraViewController/blob/master/IPDFCameraViewController/IPDFCameraViewOverlay.m#L65) which can increase the stability when refresh interval is small, please see screen capture bellow. Blue frame is the frame created by original feature points, and green frames is created by points has been corrected.
 
![detect-small](https://cloud.githubusercontent.com/assets/5063785/16615276/1925bbdc-43a8-11e6-930a-421ee677a7b1.gif)

Set [debugger flag](https://github.com/wkh237/IPDFCameraViewController/blob/master/IPDFCameraViewController/IPDFCameraViewOverlay.m#L18) to `1` to make the frames visible.

5. Added property `postEdit` and method `captureImageForPostEditWithCompletionHander` so that developers can still get non-cropped image when border detection is enable.
