### PR TITLE
Fixed Xcode9 warnings for unspecified block parameters

### DIFF
--- a/IPDFCameraViewController/IPDFCameraViewController.h
+++ b/IPDFCameraViewController/IPDFCameraViewController.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger,IPDFCameraViewType)
 
 @property (nonatomic,assign) IPDFCameraViewType cameraViewType;
 
-- (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)())completionHandler;
+- (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)(void))completionHandler;
 
 - (void)captureImageWithCompletionHander:(void(^)(NSString *imageFilePath))completionHandler;
 

--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -201,7 +201,7 @@
             [EAGLContext setCurrentContext:_context];
         }
         [_glkView bindDrawable];
-        [_coreImageContext drawImage:image inRect:self.bounds fromRect:[image extent]];
+        [_coreImageContext drawImage:image inRect:self.bounds fromRect:[self cropRectForPreviewImage:image]];
         [_glkView display];
         
         if(_intrinsicContentSize.width != image.extent.size.width) {
@@ -221,6 +221,20 @@
         return CGSizeMake(1, 1); //just enough so rendering doesn't crash
     }
     return _intrinsicContentSize;
+}
+
+- (CGRect)cropRectForPreviewImage:(CIImage *)image
+{
+    CGFloat cropWidth = image.extent.size.width;
+    CGFloat cropHeight = image.extent.size.height;
+    if (image.extent.size.width>image.extent.size.height) {
+        cropWidth = image.extent.size.width;
+        cropHeight = cropWidth*self.bounds.size.height/self.bounds.size.width;
+    } else if (image.extent.size.width<image.extent.size.height) {
+        cropHeight = image.extent.size.height;
+        cropWidth = cropHeight*self.bounds.size.width/self.bounds.size.height;
+    }
+    return CGRectInset(image.extent, (image.extent.size.width-cropWidth)/2, (image.extent.size.height-cropHeight)/2);
 }
 
 - (void)enableBorderDetectFrame

--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -476,7 +476,20 @@ void saveCGImageAsJPEGToFilePath(CGImageRef imageRef, NSString *filePath)
     rectangleCoordinates[@"inputTopRight"] = [CIVector vectorWithCGPoint:rectangleFeature.topRight];
     rectangleCoordinates[@"inputBottomLeft"] = [CIVector vectorWithCGPoint:rectangleFeature.bottomLeft];
     rectangleCoordinates[@"inputBottomRight"] = [CIVector vectorWithCGPoint:rectangleFeature.bottomRight];
-    return [image imageByApplyingFilter:@"CIPerspectiveCorrection" withInputParameters:rectangleCoordinates];
+    image = [image imageByApplyingFilter:@"CIPerspectiveCorrection" withInputParameters:rectangleCoordinates];
+
+    // Fix landscape orientiation in iOS 10 by rotating image
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
+        CIFilter *transform = [CIFilter filterWithName:@"CIAffineTransform"];
+        [transform setValue:image forKey:kCIInputImageKey];
+        NSValue *rotation = [NSValue valueWithCGAffineTransform:CGAffineTransformMakeRotation((CGFloat) (-90 * (M_PI / 180)))];
+        if ([transform respondsToSelector:@selector(setValue:forKey:)]) {
+            [transform setValue:rotation forKey:[NSString stringWithFormat:@"inputTransform"]];
+        }
+        image = [transform outputImage];
+    }
+
+    return image;
 }
 
 - (CIDetector *)rectangleDetetor

--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -302,7 +302,7 @@
     }
 }
 
-- (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)())completionHandler
+- (void)focusAtPoint:(CGPoint)point completionHandler:(void(^)(void))completionHandler
 {
     AVCaptureDevice *device = self.captureDevice;
     CGPoint pointOfInterest = CGPointZero;
@@ -455,7 +455,7 @@ void saveCGImageAsJPEGToFilePath(CGImageRef imageRef, NSString *filePath)
     }
 }
 
-- (void)hideGLKView:(BOOL)hidden completion:(void(^)())completion
+- (void)hideGLKView:(BOOL)hidden completion:(void(^)(void))completion
 {
     [UIView animateWithDuration:0.1 animations:^
     {

--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -486,18 +486,6 @@ void saveCGImageAsJPEGToFilePath(CGImageRef imageRef, NSString *filePath)
     rectangleCoordinates[@"inputBottomLeft"] = [CIVector vectorWithCGPoint:rectangleFeature.bottomLeft];
     rectangleCoordinates[@"inputBottomRight"] = [CIVector vectorWithCGPoint:rectangleFeature.bottomRight];
     image = [image imageByApplyingFilter:@"CIPerspectiveCorrection" withInputParameters:rectangleCoordinates];
-
-    // Fix landscape orientiation in iOS 10 by rotating image
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
-        CIFilter *transform = [CIFilter filterWithName:@"CIAffineTransform"];
-        [transform setValue:image forKey:kCIInputImageKey];
-        NSValue *rotation = [NSValue valueWithCGAffineTransform:CGAffineTransformMakeRotation((CGFloat) (-90 * (M_PI / 180)))];
-        if ([transform respondsToSelector:@selector(setValue:forKey:)]) {
-            [transform setValue:rotation forKey:[NSString stringWithFormat:@"inputTransform"]];
-        }
-        image = [transform outputImage];
-    }
-
     return image;
 }
 

--- a/IPDFCameraViewController/Info.plist
+++ b/IPDFCameraViewController/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This will allow app to take photos</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/IPDFCameraViewController/ViewController.m
+++ b/IPDFCameraViewController/ViewController.m
@@ -37,6 +37,7 @@
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    [super viewDidAppear:animated];
     [self.cameraViewController start];
 }
 


### PR DESCRIPTION
Xcode9 ads warnings requiring block arguments to be specified as void if block accepts no arguments.